### PR TITLE
Анимация появления блока навыков при скролле

### DIFF
--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -28,26 +28,43 @@ const About = () => {
               className="rounded-full shadow-lg"
             />
           </motion.div>
-          <motion.div variants={textVariants}>
-            <h2 className="text-4xl font-bold text-text mb-4">About Me</h2>
-            <p className="text-textSecondary text-lg mb-8 ">{aboutText1}</p>
-            <p className="text-textSecondary text-lg mb-8 ">{aboutText2}</p>
-            <h3 className="text-2xl font-semibold text-text mb-2">Skills</h3>
-            <div className="space-y-6">
-              {Object.entries(skills).map(([category, items]) => (
-                <div key={category}>
-                  <h4 className="text-xl font-bold mb-2">{category}</h4>
-                  <ul className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                    {items.map((skill, index) => (
-                      <li key={index} className="flex items-center gap-2">
-                        {skill.icon} {skill.name}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </motion.div>
+          {/* Right column wrapper: text shows on mount, skills reveal on scroll */}
+          <div>
+            <motion.div variants={textVariants}>
+              <h2 className="text-4xl font-bold text-text mb-4">About Me</h2>
+              <p className="text-textSecondary text-lg mb-8 ">{aboutText1}</p>
+              <p className="text-textSecondary text-lg mb-8 ">{aboutText2}</p>
+            </motion.div>
+            <motion.div
+              initial="off"
+              whileInView="on"
+              viewport={{ once: true, amount: 0.35 }}
+              variants={{
+                off: { opacity: 0, y: 40 },
+                on: {
+                  opacity: 1,
+                  y: 0,
+                  transition: { duration: 0.8, ease: "easeOut" },
+                },
+              }}
+            >
+              <h3 className="text-2xl font-semibold text-text mb-2">Skills</h3>
+              <div className="space-y-6">
+                {Object.entries(skills).map(([category, items]) => (
+                  <div key={category}>
+                    <h4 className="text-xl font-bold mb-2">{category}</h4>
+                    <ul className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                      {items.map((skill, index) => (
+                        <li key={index} className="flex items-center gap-2">
+                          {skill.icon} {skill.name}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </motion.div>
+          </div>
         </div>
       </div>
     </motion.section>


### PR DESCRIPTION
Add scroll-triggered fade-in animation to the About section's skills block.

---
<a href="https://cursor.com/background-agent?bcId=bc-42a375a6-76b6-4cd0-8c46-cf42f872e7ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42a375a6-76b6-4cd0-8c46-cf42f872e7ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

